### PR TITLE
Improvement: Make output paths OS agnositc

### DIFF
--- a/gnn_model_w_change.py
+++ b/gnn_model_w_change.py
@@ -185,7 +185,7 @@ class AMGNN(nn.Module):
         if self.metric_network == 'gnn':
             assert (self.args.train_N_way == self.args.test_N_way)
             num_inputs = self.emb_size + self.args.train_N_way
-            print('feature:',num_inputs)
+            print('Features:',num_inputs)
             # input('0_0')
             self.gnn_obj = gnn_w.GNN_nl(args, num_inputs, nf=96, J=1)
 

--- a/main_AD_MCI_NL.py
+++ b/main_AD_MCI_NL.py
@@ -234,7 +234,7 @@ def train_batch(model, data):
 def test_one_shot(args, fold,test_root, model, test_samples=50, partition='test',io_path= 'run.log'):
     io = io_utils.IOStream(io_path)
 
-    io.cprint('\n**** TESTING BEGIN ***' )
+    io.cprint('\n*** ITERATION BEGIN ***' )
     root = test_root
     loader = Generator(root,keys = ['CN','MCI','AD'])
     [amgnn, softmax_module] = model
@@ -297,8 +297,14 @@ def test_one_shot(args, fold,test_root, model, test_samples=50, partition='test'
     io.cprint('real_label:  '+str(real_all))
     io.cprint('pre_all:  '+str(pre_all))
     io.cprint('pre_all_num:  '+str(pre_all_num))
-    io.cprint('{} correct from {} \tAccuracy: {:.3f}%)'.format(correct, total, 100.0 * correct / total))
-    io.cprint('*** TEST FINISHED ***\n'.format(correct, total, 100.0 * correct / total))
+
+    message = textwrap.dedent("""
+    *** ITERATION FINISHED ***
+    Correct: {}
+    Total: {}
+    Accuracy: {:.3f}%
+    """.format(correct, total, 100.0 * (correct / total)))
+    io.cprint(message)
 
     amgnn.train()
 

--- a/main_AD_MCI_NL.py
+++ b/main_AD_MCI_NL.py
@@ -19,10 +19,18 @@ import argparse
 import torch.optim as optim
 from torch.autograd import Variable
 import torch.nn.functional as F
+
 from utils import io_utils
 import pickle
 import os
 import time
+import textwrap
+from pathlib import Path
+
+
+
+RESULT_PATH = Path("result/")
+DATA_PATH = Path("data/")
 
 parser = argparse.ArgumentParser(description='AMGNN')
 parser.add_argument('--metric_network', type=str, default='gnn', metavar='N',
@@ -303,12 +311,12 @@ if __name__ =='__main__':
 
     timedata = time.strftime("%F")
     name = timedata + '-3-classe'
-    save_path = 'result\\{}'.format(name)
+    save_path = RESULT_PATH / name
 
-    if name not in os.listdir('result\\'):
+    if name not in os.listdir(RESULT_PATH):
         os.makedirs(save_path)
-    io = io_utils.IOStream(save_path + '\\run.log')
-    print('the result will be saved in :', save_path)
+    io = io_utils.IOStream(RESULT_PATH / 'run.log')
+    print('The result will be saved in :', save_path)
     setup_seed(args.random_seed)
 
     amgnn = models.create_models(args, cnn_dim1=2)
@@ -328,7 +336,7 @@ if __name__ =='__main__':
     test_acc = 0
     for batch_idx in range(args.iterations):
 
-        root = 'data\\AD_3_CLASS_TRAIN.pkl'
+        root = DATA_PATH / 'AD_3_CLASS_TRAIN.pkl'
         da = Generator(root, keys=['CN', 'MCI','AD'])
         data = da.get_task_batch(batch_size=args.batch_size_train, n_way=args.train_N_way,
                                  num_shots=args.train_N_shots, unlabeled_extra=args.unlabeled_extra, cuda=args.cuda)
@@ -359,17 +367,16 @@ if __name__ =='__main__':
         if (batch_idx + 1) % args.log_interval == 0:
 
             test_samples = 320
-            test_root = 'data\\AD_3_CLASS_TEST.pkl'
+            test_root = DATA_PATH / 'AD_3_CLASS_TEST.pkl'
             test_acc_aux, test_loss_ = test_one_shot(args, 0, test_root, model=[amgnn, softmax_module],
                                                      test_samples=test_samples, partition='test',
-                                                     io_path=save_path + '//run.log')
+                                                     io_path=save_path / 'run.log')
             amgnn.train()
 
             if test_acc_aux is not None and test_acc_aux >= test_acc:
                 test_acc = test_acc_aux
                 # val_acc = val_acc_aux
-                modelpath = 'result//{}//'.format(name)
-                torch.save(amgnn, modelpath + 'amgnn' + '_best_model.pkl')
+                torch.save(amgnn, save_path / 'amgnn_best_model.pkl')
             if args.dataset == 'AD':
                 io.cprint("Best test accuracy {:.4f} \n".format(test_acc))
 

--- a/result/the results will be saved in this forder.txt
+++ b/result/the results will be saved in this forder.txt
@@ -1,1 +1,0 @@
-the results will be saved in this forder


### PR DESCRIPTION
### Change summary

- `main_AD_MCI_NL.py` input and output paths are now compatible with both Windows and Unix systems
- Tidied up some of the GNN training outputs
- Created `result/Readme`

### Checked

- That file paths are exported correctly on Windows, Mac and Linux
- Training outputs work correctly